### PR TITLE
Fixed typo - Wrong module name for 'Linear Algebra I'

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ A book that is also highly recommended (even if somewhat old) is:</p>
 </blockquote>
 <h5 id="technicalquestions">Technical questions</h5>
 <p>Having competitive programming experience helps a lot. In line with helping yourself ramp up on data structures and algorithms knowledge, as well as increasing general coding proficiency, buying the Competitive Programming book authored by one of our own NUS Lecturer may be useful. There is a free and complementing tool <a href="http://uhunt.felix-halim.net/"><a href="http://uhunt.felix-halim.net/">http://uhunt.felix-halim.net/</a></a> that categorizes many UVa problems into problem categories. This is helpful if you prefer a systematic manner of building up your core algorithm knowledge.</p>
-<p>A strong mathematical background is extremely important. Do not ever neglect your core mathematics modules (especially CS1231 and CS1101R) even if you find them to be foreign or difficult.   </p>
+<p>A strong mathematical background is extremely important. Do not ever neglect your core mathematics modules (especially CS1231 and MA1101R) even if you find them to be foreign or difficult.   </p>
 <h4 id="interviewskills">Interview skills</h4>
 <p>// TODO</p>
 <h5 id="whiteboardingandthemetagame">Whiteboarding and the meta-game</h5>


### PR DESCRIPTION
Replaced 'CS1101R' with 'MA1101R'
